### PR TITLE
Fix path traversal in GET /api/chat-modes/:modeId

### DIFF
--- a/backend/src/routes/chatModes.js
+++ b/backend/src/routes/chatModes.js
@@ -95,9 +95,14 @@ router.get('/chat-modes', async (req, res) => {
  * GET /api/chat-modes/:modeId
  * Returns a specific chat mode configuration
  */
+const VALID_MODE_ID = /^[a-z0-9][a-z0-9-]{0,63}$/
+
 router.get('/chat-modes/:modeId', async (req, res) => {
   try {
     const { modeId } = req.params
+    if (!VALID_MODE_ID.test(modeId)) {
+      return res.status(400).json({ error: 'Invalid mode id' })
+    }
     const filePath = path.join(PROMPTS_DIR, `${modeId}.json`)
 
     const mode = await loadModeConfig(filePath)


### PR DESCRIPTION
## Summary

`GET /api/chat-modes/:modeId` in [backend/src/routes/chatModes.js](backend/src/routes/chatModes.js) joined the `modeId` route parameter directly into a filesystem path with no validation:

```js
const filePath = path.join(PROMPTS_DIR, `${modeId}.json`)
```

Express decodes URL-encoded characters in route parameters, so a request like `GET /api/chat-modes/..%2F..%2Fsome-file` resolves `modeId` to `../../some-file` and `path.join` escapes `PROMPTS_DIR`. Any `.json` file readable by the backend process could be disclosed through the response.

## Fix

Validate `modeId` against a strict allowlist regex (`^[a-z0-9][a-z0-9-]{0,63}$`) before constructing the path, and return `400` for anything else. The eight shipped mode ids (`agent`, `planner`, `help-chat`, `brainstorm`, `discuss`, `edit`, `explore`, `generate`) all match.

## Test plan

- [ ] `curl http://localhost:<port>/api/chat-modes/agent` → 200 with mode config
- [ ] `curl http://localhost:<port>/api/chat-modes/..%2F..%2Fpackage` → 400 (previously would attempt to read `backend/package.json`)
- [ ] `curl http://localhost:<port>/api/chat-modes/nonexistent` → 404
- [ ] `curl http://localhost:<port>/api/chat-modes/UPPER` → 400